### PR TITLE
fix(ci): 修正Maven部署配置文件路径

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         
     - name: Deploy structure-admin
       run: |
-        mvn clean deploy -P release,oss -Dmaven.test.skip=true -Drevision=$RELEASE_VERSION -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true -s ../.mvn/settings.xml
+        mvn clean deploy -P release,oss -Dmaven.test.skip=true -Drevision=$RELEASE_VERSION -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true -s .mvn/settings.xml
       env:
         OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
- 将Maven部署命令中的settings.xml路径从../.mvn/settings.xml修正为.mvn/settings.xml
- 确保部署流程能够正确找到Maven配置文件
- 避免因路径错误导致的部署失败问题